### PR TITLE
Possible wrong required tag (SOPInstanceUID)

### DIFF
--- a/src/dicomnode/server/input.py
+++ b/src/dicomnode/server/input.py
@@ -32,7 +32,7 @@ class AbstractInput(ImageTreeInterface, ABC):
   # Private tags should be injected, rather than put into the input
   __private_tags: Dict[int, Tuple[str, str, str, str, str]] = {}
 
-  required_tags: List[int] = [0x000800180] # SOPInstanceUID
+  required_tags: List[int] = [0x00080018] # SOPInstanceUID
   """The list of tags that must be present in a dataset to be accepted
   into the input. Consider checking SOP_mapping.py for collections of Tags."""
 


### PR DESCRIPTION
On line 72 and 73 the SOP instance UID tag has the following number:

```
    if 0x00080018 not in self.required_tags: # Tag for SOPInstance is (0x0008,0018)
      self.required_tags.append(0x00080018)
```

If required_tags is not overwritten by the user, then line 35 defines it to be:


`  required_tags: List[int] = [0x000800180] # SOPInstanceUID`

This causes dicom images to be rejected. 
